### PR TITLE
Error printing and specific SamAccount option

### DIFF
--- a/Convert-Invoke-Kerberoast.py
+++ b/Convert-Invoke-Kerberoast.py
@@ -36,7 +36,7 @@ def format_Data(fHandle):
             if "                       " in line:
                 Hash += line.strip()
             if line == '\n':
-                print('Adding {!r} to output file').format(SamAccountName)
+                print('[*] Adding {!r} to output file').format(SamAccountName)
                 Hashes.append(re.sub(r'\*.*\*',"*{0}${1}$spn*$".format(SamAccountName,DistinguishedName), Hash))
                 SamAccountName = ''
                 DistinguishedName = ''
@@ -49,7 +49,7 @@ def format_Data(fHandle):
     if SamAccountName != '' and DistinguishedName != '' and  Hash != '': # Check if there ist still a hash element not appended 
         Hashes.append(re.sub(r'\*.*\*',"*{0}${1}$spn*$".format(SamAccountName,DistinguishedName), Hash))
     
-    print("\n[+] Created {0} entries.").format(len(Hashes))
+    print("[+] Created {0} entries.").format(len(Hashes))
     return Hashes
 
 
@@ -62,7 +62,7 @@ parsed = parser.parse_args()
 
 if(os.path.isfile(parsed.inputHandle)):
 
-    print("Opening file: {0}").format(parsed.inputHandle)
+    print("[*] Opening file: {0}").format(parsed.inputHandle)
     output = format_Data(parsed.inputHandle)
     if parsed.outputHandle:
         fOutput = open(parsed.outputHandle, 'w')

--- a/Convert-Invoke-Kerberoast.py
+++ b/Convert-Invoke-Kerberoast.py
@@ -6,11 +6,6 @@ import io
 import re
 import sys
 
-# TODO Input parameter fuer einzelne Accounts
-# Zeigen wo man gerade ist
-# Richtiges exception handling (Passes raus)
-# UTF-8
-
 def format_Data(fHandle, inputSamAccountName):
     fh = io.open(fHandle, 'r')
     SamAccountName = ''

--- a/Convert-Invoke-Kerberoast.py
+++ b/Convert-Invoke-Kerberoast.py
@@ -4,6 +4,12 @@ import argparse
 import os
 import io
 import re
+import sys
+
+# TODO Input parameter fuer einzelne Accounts
+# Zeigen wo man gerade ist
+# Richtiges exception handling (Passes raus)
+# UTF-8
 
 def format_Data(fHandle):
     fh = io.open(fHandle, 'r')
@@ -30,13 +36,20 @@ def format_Data(fHandle):
             if "                       " in line:
                 Hash += line.strip()
             if line == '\n':
+                print('Adding {!r} to output file').format(SamAccountName)
                 Hashes.append(re.sub(r'\*.*\*',"*{0}${1}$spn*$".format(SamAccountName,DistinguishedName), Hash))
                 SamAccountName = ''
                 DistinguishedName = ''
                 Hash = ''
-                pass
-    except:
-        pass
+    except Exception, e:
+        print >> sys.stderr, '[-] Error: %s \n Exiting...' % e
+
+        sys.exit(1)
+    
+    if SamAccountName != '' and DistinguishedName != '' and  Hash != '': # Check if there ist still a hash element not appended 
+        Hashes.append(re.sub(r'\*.*\*',"*{0}${1}$spn*$".format(SamAccountName,DistinguishedName), Hash))
+    
+    print("\n[+] Created {0} entries.").format(len(Hashes))
     return Hashes
 
 
@@ -48,6 +61,7 @@ parser.add_argument('-w', action="store", dest="outputHandle")
 parsed = parser.parse_args()
 
 if(os.path.isfile(parsed.inputHandle)):
+
     print("Opening file: {0}").format(parsed.inputHandle)
     output = format_Data(parsed.inputHandle)
     if parsed.outputHandle:
@@ -56,7 +70,7 @@ if(os.path.isfile(parsed.inputHandle)):
             fOutput.write(element)
             fOutput.write('\n')
         fOutput.close()
-        print("Hashes written to: {0}".format(parsed.outputHandle))
+        print("[+] Hashes written to: {0}".format(parsed.outputHandle))
     else:
         for element in output:
             print(element)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ When using [Invoke-Kerberoast](https://github.com/EmpireProject/Empire/blob/mast
 Example:
 ```
 python Convert-Invoke-Kerberoast.py -f tickets.txt -w hashes.txt
+python Convert-Invoke-Kerberoast.py -f tickets.txt -w hashes.txt -a dbadmin
+python Convert-Invoke-Kerberoast.py -f tickets.txt -w hashes.txt -a dbadmin dbuser3
 ```
 
 


### PR DESCRIPTION
Added output to print in the case of errors. This should give hints to the user in case his input file is incompatible with the tool.
Also added an option to extract hashes for specific samaccountnames from bigger lists.